### PR TITLE
Prefer relative imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: package:flutter_lints/flutter.yaml
+linter:
+  rules:
+    - prefer_relative_imports


### PR DESCRIPTION
Effective Dart recommends using relative imports for files in the `lib/` directory. We should choose one or the other for consistency. This PR enables a linter suggestion and fix to change any `package:devil_scout/` imports to relative imports.